### PR TITLE
Fix bootstrap.js

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -57,9 +57,11 @@ function createVariables() {
   client.getApplications(function(err, apps) {
     if (err) throw err;
 
-    apps.each(function(err, app, offset) {
+    apps.each(function(app, next) {
       if (app.name === 'stormpath-express-sample') {
         write(app);
+      }else{
+        next();
       }
     });
 


### PR DESCRIPTION
We upgraded the node sdk in #7 and it broke the bootstrap script because the iterator methods changed.  At the moment the bootstrap script is not writing the .env file

This fixes the bootstrap script to use the new iterator signature
